### PR TITLE
chore: remove unnecessary null check

### DIFF
--- a/src/components/pages/state/race-ethnicity/utils/index.js
+++ b/src/components/pages/state/race-ethnicity/utils/index.js
@@ -61,7 +61,6 @@ const formatTableValues = timeSeriesData => {
 
       if (
         typeof dataPointValue === 'number' &&
-        dataPointValue != null &&
         !dataPointName.toLowerCase().includes('date')
       ) {
         // Format the value if the value is numeric.


### PR DESCRIPTION
The `typeof` check to confirm that `dataPointValue` is a number 
immediately precedes a check that `dataPointValue` is not null. However
all number values, including the unusual ones like `NaN` and `Infinity`
(and `0`), will pass that check. All number values will be `!= null`.
This change removes the check.

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
